### PR TITLE
Fix description trimming bug in TransactionManager

### DIFF
--- a/transaction_manager.py
+++ b/transaction_manager.py
@@ -12,7 +12,10 @@ class TransactionManager:
         try:
             amount, desc = user_input.split('/', 1)
             amount = int(amount)
-            desc = str(desc).trim()
+            # `trim` is not a valid Python string method. Using `strip` removes
+            # leading and trailing whitespace from the description so that
+            # accidental spaces don't get persisted into the log.
+            desc = str(desc).strip()
             dt = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
             uuid_str = str(uuid.uuid4())
             result = {"uuid": uuid_str, "amount": amount, "description": desc, "datetime": dt, 'category': category, 'type': transaction_type}


### PR DESCRIPTION
## Summary
- replace invalid `trim` usage with `strip` for description cleanup
- add explanation comment

## Testing
- `python -m py_compile transaction_manager.py file_manager.py CSV_manager.py bot.py`
- `python - <<'PY'
from file_manager import FileManager
from transaction_manager import TransactionManager
fm=FileManager('test_log.json','test_categories.json')
fm.init_log()
fm.init_categories()
tm=TransactionManager(fm)
print(tm.add_transaction('100/test','Dining','Expense'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_688eb04b2178833185ab6ae24beec4fc