### PR TITLE
docs: fix repo clone url and bot description

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ To install and run the SimplestBookkeepingPWA, follow these steps:
 1. Clone the repository:
 
    ```sh
-   git clone https://github.com/Dao-you/SImplestBookkeepingPWA.git
+   git clone https://github.com/Dao-you/SimplestBookkeepingPWA.git
    cd SimplestBookkeepingPWA
    ```
 
@@ -138,7 +138,7 @@ graph TD;
     H --> M[SVG/PNG Files]
 ```
 
-- Bot.py: Routes defination and processition data from frontend
+- Bot.py: Defines routes and processes data from the frontend.
 
 - File Manager: Manages file operations for storing and retrieving data.
 


### PR DESCRIPTION
## Summary
- fix repository URL in installation guide
- clarify bot.py description in project overview

## Testing
- `python -m markdown readme.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688eb27408b4833185b1247c32ede6e5