### PR TITLE
Render pages with sample data for GitHub Pages preview

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,38 @@
+name: Render Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install -r requirements.txt
+      - run: python scripts/render_pages.py
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 logs/*
-__pycache__
+__pycache__/
 BookKeeping.zip
 log.json
 categories.json
 SSLconfig.json
+public/

--- a/scripts/render_pages.py
+++ b/scripts/render_pages.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import json
+import shutil
+
+# Allow importing from repository root
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from flask import render_template
+from bot import app
+
+OUTPUT_DIR = 'public'
+
+# Use sample data
+CATEGORIES_FILE = 'example_categories.json'
+LOG_FILE = 'example_log.json'
+
+# Ensure output directory exists
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+shutil.copytree('static', os.path.join(OUTPUT_DIR, 'static'), dirs_exist_ok=True)
+shutil.copy('manifest.json', OUTPUT_DIR)
+shutil.copy('sw.js', OUTPUT_DIR)
+
+# Provide API data files for front-end scripts
+shutil.copy(LOG_FILE, os.path.join(OUTPUT_DIR, 'get_log'))
+shutil.copy(CATEGORIES_FILE, os.path.join(OUTPUT_DIR, 'get_categories'))
+
+
+def replace_paths(html: str) -> str:
+    replacements = {
+        'href="/manifest.json"': 'href="manifest.json"',
+        "fetch('/get_log')": "fetch('get_log')",
+        "fetch('/get_categories')": "fetch('get_categories')",
+        'href="/edit_categories"': 'href="edit_categories.html"',
+        'href="/load_CSV"': 'href="load_CSV.html"',
+        'href="/chart"': 'href="chart.html"',
+    }
+    for old, new in replacements.items():
+        html = html.replace(old, new)
+    return html
+
+
+# Replace url_for to generate relative static paths
+@app.context_processor
+def override_url_for():
+    def _url_for(endpoint, **values):
+        if endpoint == 'static':
+            filename = values.get('filename', '')
+            return f'static/{filename}'
+        return endpoint
+    return dict(url_for=_url_for)
+
+
+with app.app_context():
+    with open(CATEGORIES_FILE) as f:
+        categories = json.load(f)
+    with open(LOG_FILE) as f:
+        log_data = json.load(f)
+    entry = log_data['log'][0]
+
+    pages = {
+        'index.html': render_template('home.html', expenseCategory=categories['expense'], incomeCategory=categories['income']),
+        'edit_categories.html': render_template('edit_categories.html', categories=categories),
+        'chart.html': render_template('chart.html'),
+        'load_CSV.html': render_template('load_CSV.html'),
+        'result.html': render_template('result.html', info='Demo preview message'),
+        'edit_log.html': render_template('edit_log.html', entry=entry, expenseCategory=categories['expense'], incomeCategory=categories['income']),
+    }
+
+    for filename, html in pages.items():
+        html = replace_paths(html)
+        with open(os.path.join(OUTPUT_DIR, filename), 'w', encoding='utf-8') as f:
+            f.write(html)


### PR DESCRIPTION
## Summary
- Add workflow to render templates with example data and publish to GitHub Pages
- Provide script that generates static pages and API stubs for preview
- Ignore generated output directory

## Testing
- `pip install -r requirements.txt`
- `python scripts/render_pages.py && ls public`


------
https://chatgpt.com/codex/tasks/task_e_689e1d34c0548331a9fd8f7cc7c117ef